### PR TITLE
Add support for shiny prerendered Rmd docs

### DIFF
--- a/poly-R.el
+++ b/poly-R.el
@@ -519,7 +519,7 @@ block. Thus, output file names don't comply with
     (doc "Shiny Rmd Application")
     (match (save-excursion
              (goto-char (point-min))
-             (re-search-forward "^[ \t]*runtime:[ \t]+shiny[ \t]*$" nil t)))
+             (re-search-forward "^[ \t]*runtime:[ \t]+shiny\\(?:[ \t]\\|_prerendered\\)*$" nil t)))
     (command (if (equal id "Rmd-ESS")
                  "rmarkdown::run('%I')\n"
                "Rscript -e \"rmarkdown::run('%I')\""))))
@@ -532,7 +532,7 @@ block. Thus, output file names don't comply with
                      :to
                      '(("html" "html" "Shiny Web App")))
   "Shiny exporter of Rmd documents in stand alone shell.
-The Rmd yaml preamble must contain runtime: shiny declaration."
+The Rmd yaml preamble must contain runtime: shiny or runtime: shiny_prerendered declaration."
   :group 'polymode-export
   :type 'object)
 
@@ -545,7 +545,7 @@ The Rmd yaml preamble must contain runtime: shiny declaration."
                         '(("html" "html" "Shiny Web App"))
                         :function 'pm--ess-run-command)
   "Shiny exporter of Rmd documents within ESS process.
-The Rmd yaml preamble must contain runtime: shiny declaration."
+The Rmd yaml preamble must contain runtime: shiny or runtime: shiny_prerendered declaration."
   :group 'polymode-export
   :type 'object)
 


### PR DESCRIPTION
It's now possible to use the shiny prerendered option to have shiny powered Rmd documents (https://rmarkdown.rstudio.com/authoring_shiny_prerendered.html).
This PR modify the regex to also detect `runtime: shiny_prerendered` and can help closing the issue https://github.com/polymode/polymode/issues/248