### PR TITLE
Attempt fixing hangs with large `.libPaths()`

### DIFF
--- a/poly-R.el
+++ b/poly-R.el
@@ -226,7 +226,9 @@ list_templates <-
   "Menu for poly-r+markdown-mode"
   '("RMarkdown"
     ("Templates"
-     :active (ess-get-next-available-process "R" t)
+     ;; TODO: Use `ess-get-next-available-bg-process' after release
+     :active (and ess-can-eval-in-background
+                  (ess-get-next-available-process "R" t))
      :filter poly-r-rmarkdown-templates-menu)))
 
 (define-key poly-markdown+r-mode-map (kbd "M-n M-m") #'poly-r-rmarkdown-create-from-template)

--- a/poly-R.el
+++ b/poly-R.el
@@ -170,7 +170,7 @@ list_templates <-
          (templates (process-get proc :rmarkdown-templates)))
     (unless templates
       (setq templates (ignore-errors
-                        (poly-r-rmarkdown-templates proc 0.05)))
+                        (poly-r-rmarkdown-templates proc 0.2)))
       (when (< 2000 (length templates))
         (process-put proc :rmarkdown-templates templates)))
     (mapcar (lambda (el)

--- a/poly-R.el
+++ b/poly-R.el
@@ -147,7 +147,7 @@ list_templates <-
   }\n
  list_templates(%s)})\n")
 
-(defun poly-r-rmarkdown-templates (&optional proc)
+(defun poly-r-rmarkdown-templates (&optional proc timeout)
   (let* ((ess-dialect "R")
          (proc (or proc (ess-get-next-available-process "R" t)))
          (user-dirs (if poly-r-rmarkdown-template-dirs
@@ -157,7 +157,7 @@ list_templates <-
                                            "\", \""))
                       "c()"))
          (cmd (format poly-r--rmarkdown-template-command user-dirs)))
-    (with-current-buffer (ess-command cmd nil nil nil nil proc)
+    (with-current-buffer (ess-command cmd nil nil nil nil proc nil timeout)
       (goto-char (point-min))
       (if (save-excursion (re-search-forward "\\+ Error" nil t))
           (error "%s" (buffer-string))
@@ -169,7 +169,8 @@ list_templates <-
   (let* ((proc (ess-get-next-available-process "R" t))
          (templates (process-get proc :rmarkdown-templates)))
     (unless templates
-      (setq templates (poly-r-rmarkdown-templates proc))
+      (setq templates (ignore-errors
+                        (poly-r-rmarkdown-templates proc 0.05)))
       (when (< 2000 (length templates))
         (process-put proc :rmarkdown-templates templates)))
     (mapcar (lambda (el)

--- a/poly-R.el
+++ b/poly-R.el
@@ -81,6 +81,14 @@ templates."
   :type '(repeat string)
   :group 'poly-R)
 
+(defcustom poly-r-can-eval-in-background t
+  "Whether poly-R can use background commands.
+This is similar to `ess-can-eval-in-background' but limited to
+poly-R."
+  :type 'boolean
+  :group 'poly-R)
+
+
 (define-innermode poly-r-markdown-inline-code-innermode poly-markdown-inline-code-innermode
   :mode 'ess-r-mode
   :head-matcher (cons "\\(?:^\\|[^`]\\)\\(`r[ #]\\)" 1))
@@ -227,7 +235,8 @@ list_templates <-
   '("RMarkdown"
     ("Templates"
      ;; TODO: Use `ess-get-next-available-bg-process' after release
-     :active (and ess-can-eval-in-background
+     :active (and poly-r-can-eval-in-background
+                  ess-can-eval-in-background
                   (ess-get-next-available-process "R" t))
      :filter poly-r-rmarkdown-templates-menu)))
 


### PR DESCRIPTION
We found out in https://github.com/emacs-ess/ESS/issues/1110 and in ulterior debugging sessions that poly-R causes @mmaechler's Emacs to hang, apparently becuase of a large `.libPaths()`. This happens in the `ess-command` call by the poly-R menu.

To fix this, this PR:

- Checks that `ess-can-eval-in-background` is non-nil before attempting an `ess-command`.

- Adds a timeout of 200ms to the command when called in the background by the menu. This timeout is not used when called explicitly by a user command. This should avoid hanging too much.

- Adds a `poly-r-can-eval-in-background` variable in case the above is insufficient. Martin could set it to `nil` in case the background evals cause too much sluggishness (I'm hoping the timeout will avoid hangs).